### PR TITLE
Fix listoftype is not empty when count is >1

### DIFF
--- a/htdocs/public/members/new.php
+++ b/htdocs/public/members/new.php
@@ -570,7 +570,10 @@ if (empty($conf->global->MEMBER_NEWFORM_FORCETYPE))
     $tmp = array_keys($listoftype);
     $defaulttype = '';
     $isempty = 1;
-    if (count($listoftype) == 1) { $defaulttype = $tmp[0]; $isempty = 0; }
+    if (!empty($listoftype)) { 
+        $defaulttype = count($listoftype) == 1 ? $tmp[0] : '' ; 
+        $isempty = 0; 
+    }
     print '<tr><td class="titlefield">'.$langs->trans("Type").' <FONT COLOR="red">*</FONT></td><td>';
     print $form->selectarray("type", $adht->liste_array(), GETPOST('type') ?GETPOST('type') : $defaulttype, $isempty);
     print '</td></tr>'."\n";


### PR DESCRIPTION
When there's multiple adherent type the count list is not equals to one, so $isempty was set to 1